### PR TITLE
Add landing page and dashboard layout

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import RequireAuth from '@/components/RequireAuth'
+import { useSupabaseClient } from '@supabase/auth-helpers-react'
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const supabase = useSupabaseClient()
+  const logout = () => supabase.auth.signOut()
+
+  return (
+    <RequireAuth>
+      <div className="flex min-h-screen">
+        <aside className="w-60 bg-gray-100 p-4">
+          <h1 className="text-xl font-bold mb-4">Status Pulse</h1>
+          <nav className="space-y-2">
+            <a href="/dashboard" className="block">
+              Projetos
+            </a>
+          </nav>
+        </aside>
+        <div className="flex-1 flex flex-col">
+          <header className="border-b p-4 flex justify-end">
+            <button onClick={logout} className="text-sm underline">
+              Sign out
+            </button>
+          </header>
+          <main className="flex-1 p-4">{children}</main>
+        </div>
+      </div>
+    </RequireAuth>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import RequireAuth from '@/components/RequireAuth'
 import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react'
 import { useEffect, useState } from 'react'
 
@@ -44,18 +43,10 @@ export default function Dashboard() {
     }
   }
 
-  const logout = () => supabase.auth.signOut()
-
   return (
-    <RequireAuth>
-      <div className="max-w-2xl mx-auto p-4 space-y-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-2xl font-bold">Dashboard</h1>
-          <button onClick={logout} className="text-sm underline">
-            Sign out
-          </button>
-        </div>
-        <form onSubmit={createProject} className="flex gap-2">
+    <div className="max-w-2xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <form onSubmit={createProject} className="flex gap-2">
           <input
             placeholder="Project name"
             value={name}
@@ -80,6 +71,5 @@ export default function Dashboard() {
           ))}
         </ul>
       </div>
-    </RequireAuth>
   )
 }

--- a/src/app/dashboard/projects/[id]/page.tsx
+++ b/src/app/dashboard/projects/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import RequireAuth from '@/components/RequireAuth'
 import { useSupabaseClient } from '@supabase/auth-helpers-react'
 import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -64,8 +63,7 @@ export default function ProjectPage() {
   }
 
   return (
-    <RequireAuth>
-      <div className="max-w-2xl mx-auto p-4 space-y-4">
+    <div className="max-w-2xl mx-auto space-y-4">
         <h1 className="text-xl font-bold">{project?.name}</h1>
         <form onSubmit={createService} className="flex flex-col gap-2">
           <input
@@ -120,6 +118,5 @@ export default function ProjectPage() {
           </tbody>
         </table>
       </div>
-    </RequireAuth>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,31 @@
-'use client'
-import { useSession } from '@supabase/auth-helpers-react'
-import { useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+"use client"
+
+import { useSession } from "@supabase/auth-helpers-react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 export default function Home() {
-  const session = useSession()
-  const router = useRouter()
+  const session = useSession();
+  const router = useRouter();
 
   useEffect(() => {
     if (session) {
-      router.replace('/dashboard')
-    } else if (session === null) {
-      router.replace('/login')
+      router.replace("/dashboard");
     }
-  }, [session, router])
+  }, [session, router]);
 
-  return null
+  if (session) return null;
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center gap-6 p-4 text-center">
+      <h1 className="text-4xl font-bold">Status Pulse</h1>
+      <p className="max-w-md text-lg">
+        Monitoramento de serviços em tempo real para garantir a continuidade do
+        seu negócio.
+      </p>
+      <a href="/login" className="bg-black text-white px-6 py-2 rounded">
+        Login
+      </a>
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- create a public landing page with login button
- add dashboard layout with sidebar and header
- adjust dashboard pages to use the new layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857793c9554832eaf490c61c4845989