### PR TITLE
Fix auth check to avoid redirect loop

### DIFF
--- a/src/app/dashboard/projects/[slug]/services/page.tsx
+++ b/src/app/dashboard/projects/[slug]/services/page.tsx
@@ -29,21 +29,25 @@ export default function ServicesPage() {
   useEffect(() => {
     const load = async () => {
       if (!user || !slug) return
-      const { data: proj } = await supabase
+      console.log('loading project', { slug, user })
+      const { data: proj, error: projError } = await supabase
         .from('projects')
         .select('id,name,user_id')
         .eq('slug', slug)
         .single()
+      console.log('project result', { proj, projError })
       if (!proj || proj.user_id !== user.id) {
+        console.warn('Project not found or unauthorized', { proj, userId: user.id })
         alert('Projeto não encontrado')
         router.replace('/dashboard')
         return
       }
       setProject(proj)
-      const { data: servs } = await supabase
+      const { data: servs, error: servsError } = await supabase
         .from('services')
         .select('id,name,status,last_checked_at')
         .eq('project_id', proj.id)
+      console.log('services result', { servs, servsError })
       setServices(servs || [])
       setLoading(false)
     }

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,17 +1,18 @@
 'use client'
-import { useSession } from '@supabase/auth-helpers-react'
+import { useSessionContext } from '@supabase/auth-helpers-react'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 
 export default function RequireAuth({ children }: { children: React.ReactNode }) {
-  const session = useSession()
+  const { session, isLoading } = useSessionContext()
   const router = useRouter()
   useEffect(() => {
-    if (session === null) {
+    if (!isLoading && session === null) {
       router.replace('/login')
     }
-  }, [session, router])
+  }, [session, isLoading, router])
 
+  if (isLoading) return null
   if (!session) return null
   return <>{children}</>
 }


### PR DESCRIPTION
## Summary
- handle session loading state before redirecting to login

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68577f60b838832e9206614c4bac2c61