### PR TITLE
Add header input list component

### DIFF
--- a/src/app/dashboard/projects/[slug]/services/new/page.tsx
+++ b/src/app/dashboard/projects/[slug]/services/new/page.tsx
@@ -3,6 +3,7 @@
 import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react'
 import { useParams, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import HeaderInputList, { Header } from '@/components/HeaderInputList'
 
 interface Project {
   id: string
@@ -21,7 +22,7 @@ export default function NewServicePage() {
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
   const [method, setMethod] = useState('GET')
-  const [headers, setHeaders] = useState('{}')
+  const [headers, setHeaders] = useState<Header[]>([])
   const [body, setBody] = useState('')
   const [expectedStatus, setExpectedStatus] = useState(200)
   const [expectedBody, setExpectedBody] = useState('')
@@ -51,13 +52,10 @@ export default function NewServicePage() {
       alert('Preencha os campos obrigatórios')
       return
     }
-    let headersObj: Record<string, string> = {}
-    try {
-      headersObj = headers ? JSON.parse(headers) : {}
-    } catch {
-      alert('Headers inválidos')
-      return
-    }
+    const headersObj: Record<string, string> = {}
+    headers.forEach((h) => {
+      if (h.key) headersObj[h.key] = h.value
+    })
     const { error } = await supabase.from('services').insert({
       project_id: project!.id,
       name,
@@ -107,12 +105,7 @@ export default function NewServicePage() {
           <option key={m}>{m}</option>
         ))}
       </select>
-      <textarea
-        className="border p-2 rounded font-mono text-sm"
-        placeholder="Headers (JSON)"
-        value={headers}
-        onChange={(e) => setHeaders(e.target.value)}
-      />
+      <HeaderInputList headers={headers} onChange={setHeaders} />
       {method !== 'GET' && (
         <textarea
           className="border p-2 rounded font-mono text-sm"

--- a/src/components/HeaderInputList.tsx
+++ b/src/components/HeaderInputList.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import React from 'react'
+
+export type Header = { key: string; value: string }
+
+export type HeaderInputListProps = {
+  headers: Header[]
+  onChange: (headers: Header[]) => void
+}
+
+export default function HeaderInputList({ headers, onChange }: HeaderInputListProps) {
+  // Ensure at least one empty row at the end
+  const rows = [...headers]
+  if (rows.length === 0 || rows[rows.length - 1].key || rows[rows.length - 1].value) {
+    rows.push({ key: '', value: '' })
+  }
+
+  const update = (index: number, field: 'key' | 'value', value: string) => {
+    const copy = [...rows]
+    copy[index] = { ...copy[index], [field]: value }
+    if (index === rows.length - 1 && (copy[index].key || copy[index].value)) {
+      copy.push({ key: '', value: '' })
+    }
+    onChange(copy.filter((h) => h.key || h.value))
+  }
+
+  const remove = (index: number) => {
+    const copy = rows.filter((_, i) => i !== index)
+    if (copy.length === 0 || copy[copy.length - 1].key || copy[copy.length - 1].value) {
+      copy.push({ key: '', value: '' })
+    }
+    onChange(copy.filter((h) => h.key || h.value))
+  }
+
+  return (
+    <div className="space-y-2">
+      {rows.map((h, idx) => (
+        <div className="grid grid-cols-[1fr_1fr_auto] gap-2" key={idx}>
+          <input
+            className="border p-2 rounded"
+            placeholder="Authorization"
+            value={h.key}
+            onChange={(e) => update(idx, 'key', e.target.value)}
+          />
+          <input
+            className="border p-2 rounded"
+            placeholder="Bearer abc123"
+            value={h.value}
+            onChange={(e) => update(idx, 'value', e.target.value)}
+          />
+          {rows.length > 1 && idx < rows.length - 1 && (
+            <button
+              type="button"
+              onClick={() => remove(idx)}
+              className="text-red-600 px-2"
+            >
+              &times;
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `HeaderInputList` component for dynamic header pairs
- integrate `HeaderInputList` into service creation page

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68581a4112a0832e8197f95cd93a7a56