### PR TITLE
Add RequestBodyInput component for JSON body

### DIFF
--- a/src/app/dashboard/projects/[slug]/services/[serviceId]/edit/page.tsx
+++ b/src/app/dashboard/projects/[slug]/services/[serviceId]/edit/page.tsx
@@ -3,6 +3,7 @@
 import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react'
 import { useParams, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import RequestBodyInput from '@/components/RequestBodyInput'
 
 interface Project {
   id: string
@@ -142,11 +143,9 @@ export default function EditServicePage() {
         onChange={(e) => setHeaders(e.target.value)}
       />
       {method !== 'GET' && (
-        <textarea
-          className="border p-2 rounded font-mono text-sm"
-          placeholder="Body"
+        <RequestBodyInput
           value={body}
-          onChange={(e) => setBody(e.target.value)}
+          onChange={(val) => setBody(val)}
         />
       )}
       <input

--- a/src/app/dashboard/projects/[slug]/services/new/page.tsx
+++ b/src/app/dashboard/projects/[slug]/services/new/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import HeaderInputList, { Header } from '@/components/HeaderInputList'
 import TestConfigurationButton from '@/components/TestConfigurationButton'
+import RequestBodyInput from '@/components/RequestBodyInput'
 
 interface Project {
   id: string
@@ -108,11 +109,9 @@ export default function NewServicePage() {
       </select>
       <HeaderInputList headers={headers} onChange={setHeaders} />
       {method !== 'GET' && (
-        <textarea
-          className="border p-2 rounded font-mono text-sm"
-          placeholder="Body"
+        <RequestBodyInput
           value={body}
-          onChange={(e) => setBody(e.target.value)}
+          onChange={(val) => setBody(val)}
         />
       )}
       <input

--- a/src/components/RequestBodyInput.tsx
+++ b/src/components/RequestBodyInput.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export type RequestBodyInputProps = {
+  value: string
+  onChange: (value: string, isValid: boolean) => void
+}
+
+export default function RequestBodyInput({ value, onChange }: RequestBodyInputProps) {
+  const [text, setText] = useState(value)
+  const [isValid, setIsValid] = useState(true)
+
+  useEffect(() => {
+    setText(value)
+    try {
+      if (value.trim()) {
+        JSON.parse(value)
+      }
+      setIsValid(true)
+    } catch {
+      setIsValid(false)
+    }
+  }, [value])
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value
+    setText(val)
+    try {
+      if (val.trim()) {
+        JSON.parse(val)
+      }
+      setIsValid(true)
+      onChange(val, true)
+    } catch {
+      setIsValid(false)
+      onChange(val, false)
+    }
+  }
+
+  return (
+    <div className="space-y-1">
+      <textarea
+        className={`border rounded p-2 font-mono text-sm w-full ${isValid ? 'border-green-500' : 'border-red-500'}`}
+        placeholder='{ "env": "production" }'
+        value={text}
+        onChange={handleChange}
+      />
+      <p className={`text-sm ${isValid ? 'text-green-600' : 'text-red-600'}`}>
+        {isValid ? 'JSON válido ✅' : 'JSON inválido ❌'}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `<RequestBodyInput>` React component for editing HTTP body as JSON
- use the new component on the new service form
- use the new component on the edit service form

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68581f736998832e90524242bc027038