### PR TITLE
Implement public status page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4">
+      <div className="text-center space-y-2">
+        <h1 className="text-2xl font-bold">Página não encontrada</h1>
+        <p>A página que você procura não existe.</p>
+        <Link href="/" className="text-blue-600 underline">
+          Voltar ao início
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/status/[slug]/page.tsx
+++ b/src/app/status/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import type { Database } from '@/types/database'
+import { notFound } from 'next/navigation'
 
 const supabase = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -8,65 +9,172 @@ const supabase = createClient<Database>(
 
 export const revalidate = 60
 
+function timeAgo(date: Date) {
+  const diff = Date.now() - date.getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 60) return `${minutes} minuto${minutes === 1 ? '' : 's'} atrás`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hora${hours === 1 ? '' : 's'} atrás`
+  const days = Math.floor(hours / 24)
+  return `${days} dia${days === 1 ? '' : 's'} atrás`
+}
+
 async function getData(slug: string) {
   const { data: project } = await supabase
     .from('projects')
     .select('id,name')
     .eq('slug', slug)
     .single()
+
   if (!project) return null
+
   const { data: services } = await supabase
     .from('services')
     .select('id,name,status,last_checked_at')
     .eq('project_id', project.id)
+
+  const serviceIds = services?.map((s) => s.id) || []
+
   const { data: incidents } = await supabase
     .from('incidents')
-    .select('title,status,started_at,resolved_at')
-    .eq('service_id', services?.map((s) => s.id))
+    .select('id,title,status,started_at,resolved_at,service_id')
+    .in('service_id', serviceIds)
+    .neq('status', 'resolved')
     .order('started_at', { ascending: false })
-  return { project, services: services || [], incidents: incidents || [] }
+    .limit(5)
+
+  const since = new Date()
+  since.setDate(since.getDate() - 6)
+  since.setHours(0, 0, 0, 0)
+
+  const { data: checks } = await supabase
+    .from('status_checks')
+    .select('checked_at,success')
+    .in('service_id', serviceIds)
+    .gte('checked_at', since.toISOString())
+
+  const uptimeMap: Record<string, { ok: number; failures: number }> = {}
+  checks?.forEach((c) => {
+    const day = c.checked_at.split('T')[0]
+    if (!uptimeMap[day]) uptimeMap[day] = { ok: 0, failures: 0 }
+    if (c.success) uptimeMap[day].ok++
+    else uptimeMap[day].failures++
+  })
+  const uptime: { day: string; ok: number; failures: number }[] = []
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(since)
+    d.setDate(d.getDate() + i)
+    const key = d.toISOString().split('T')[0]
+    uptime.push({ day: key, ok: uptimeMap[key]?.ok || 0, failures: uptimeMap[key]?.failures || 0 })
+  }
+
+  const lastCheck = services?.reduce<string | null>((acc, s) => {
+    if (s.last_checked_at && (!acc || new Date(s.last_checked_at) > new Date(acc))) {
+      return s.last_checked_at
+    }
+    return acc
+  }, null) || null
+
+  return {
+    project,
+    services: services || [],
+    incidents: incidents || [],
+    uptime,
+    lastCheck,
+  }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function Page({ params }: any) {
+export default async function Page({ params }: { params: { slug: string } }) {
   const data = await getData(params.slug)
   if (!data) {
-    return <div className="p-4">Project not found</div>
+    notFound()
   }
+
+  const serviceMap = new Map(data.services.map((s) => [s.id, s.name]))
+  const lastCheckText = data.lastCheck ? timeAgo(new Date(data.lastCheck)) : null
+  const baseUrl = process.env.NEXT_PUBLIC_STATUS_BASE_URL || ''
+  const publicUrl = `${baseUrl}/status/${params.slug}`
+
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-6">
-      <h1 className="text-2xl font-bold">{data.project.name}</h1>
-      <table className="w-full border">
-        <thead>
-          <tr className="border-b">
-            <th className="p-2 text-left">Service</th>
-            <th className="p-2">Status</th>
-            <th className="p-2">Last Check</th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.services.map((s) => (
-            <tr key={s.name} className="border-b">
-              <td className="p-2">{s.name}</td>
-              <td className="p-2">
-                <span className={`px-2 py-1 rounded text-white ${s.status === 'online' ? 'bg-green-500' : s.status === 'degraded' ? 'bg-yellow-500' : 'bg-red-500'}`}>{s.status}</span>
-              </td>
-              <td className="p-2">{s.last_checked_at ?? '-'}</td>
+      <div className="text-center space-y-1">
+        <h1 className="text-2xl font-bold">{data.project.name}</h1>
+        <p className="text-sm text-gray-500">{publicUrl}</p>
+        {lastCheckText && (
+          <p className="text-xs text-gray-500">Última atualização: {lastCheckText}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="font-semibold">Serviços monitorados</h2>
+        <table className="w-full border text-sm">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2 text-left">Serviço</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Última checagem</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-      <div>
-        <h2 className="font-bold mb-2">Incidents</h2>
+          </thead>
+          <tbody>
+            {data.services.map((s) => (
+              <tr key={s.id} className="border-b">
+                <td className="p-2">{s.name}</td>
+                <td className="p-2">
+                  <span
+                    className={`px-2 py-1 rounded text-white ${
+                      s.status === 'online'
+                        ? 'bg-green-500'
+                        : s.status === 'degraded'
+                        ? 'bg-yellow-500'
+                        : 'bg-red-500'
+                    }`}
+                  >
+                    {s.status ?? 'desconhecido'}
+                  </span>
+                </td>
+                <td className="p-2">
+                  {s.last_checked_at
+                    ? new Date(s.last_checked_at).toLocaleString()
+                    : '-'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="font-semibold">Incidentes recentes</h2>
+        {data.incidents.length === 0 && (
+          <p className="text-sm text-gray-500">Nenhum incidente aberto.</p>
+        )}
         <ul className="space-y-2">
-          {data.incidents.map((i, idx) => (
-            <li key={idx} className="border p-2 rounded">
+          {data.incidents.map((i) => (
+            <li key={i.id} className="border p-2 rounded">
               <p className="font-semibold">{i.title}</p>
-              <p>{i.status}</p>
+              <p className="text-sm">Serviço: {serviceMap.get(i.service_id) || i.service_id}</p>
+              <p className="text-sm">Iniciado em {new Date(i.started_at).toLocaleString()}</p>
+              <p className="text-sm">Status: {i.status}</p>
             </li>
           ))}
         </ul>
       </div>
+
+      {data.uptime.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="font-semibold">Uptime (últimos 7 dias)</h2>
+          <div className="flex gap-1">
+            {data.uptime.map((u) => (
+              <div
+                key={u.day}
+                className={`flex-1 h-2 rounded-sm ${u.failures > 0 ? 'bg-red-500' : 'bg-green-500'}`}
+                title={`${u.day} - ${u.failures > 0 ? 'Falhas' : 'OK'}`}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- create custom 404 page for missing resources
- expand `/status/[slug]` with project info, service list, incidents and uptime

## Testing
- `npx eslint src/app/status/[slug]/page.tsx`
- `npx eslint src/app/not-found.tsx`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858218dc584832e9b4fc896b8ba74b0