### PR TITLE
Add incidents management pages

### DIFF
--- a/src/app/dashboard/projects/[slug]/incidents/new/page.tsx
+++ b/src/app/dashboard/projects/[slug]/incidents/new/page.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react'
+import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+interface Project {
+  id: string
+  name: string
+  user_id: string
+}
+
+interface Service {
+  id: string
+  name: string
+}
+
+export default function NewIncidentPage() {
+  const supabase = useSupabaseClient()
+  const user = useUser()
+  const router = useRouter()
+  const { slug } = useParams<{ slug: string }>()
+  const [project, setProject] = useState<Project | null>(null)
+  const [services, setServices] = useState<Service[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [serviceId, setServiceId] = useState('')
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [startedAt, setStartedAt] = useState(
+    new Date().toISOString().slice(0, 16),
+  )
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user || !slug) return
+      const { data: proj } = await supabase
+        .from('projects')
+        .select('id,name,user_id')
+        .eq('slug', slug)
+        .single()
+      if (!proj || proj.user_id !== user.id) {
+        alert('Projeto não encontrado')
+        router.replace('/dashboard')
+        return
+      }
+      setProject(proj)
+      const { data: servs } = await supabase
+        .from('services')
+        .select('id,name')
+        .eq('project_id', proj.id)
+      setServices(servs || [])
+      if (servs && servs[0]) setServiceId(servs[0].id)
+      setLoading(false)
+    }
+    load()
+  }, [user, slug, supabase, router])
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!serviceId || !title) return
+    const { error } = await supabase.from('incidents').insert({
+      service_id: serviceId,
+      title,
+      description: description || null,
+      status: 'open',
+      started_at: new Date(startedAt).toISOString(),
+    })
+    if (!error) {
+      router.push(`/dashboard/projects/${slug}/incidents`)
+    } else {
+      alert(error.message)
+    }
+  }
+
+  if (loading) return <div>Carregando...</div>
+  if (!project) return null
+
+  return (
+    <form onSubmit={save} className="max-w-2xl mx-auto flex flex-col gap-2">
+      <h1 className="text-xl font-bold">Novo incidente em {project.name}</h1>
+      <select
+        className="border p-2 rounded"
+        value={serviceId}
+        onChange={(e) => setServiceId(e.target.value)}
+        required
+      >
+        {services.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.name}
+          </option>
+        ))}
+      </select>
+      <input
+        className="border p-2 rounded"
+        placeholder="Título"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        required
+      />
+      <textarea
+        className="border p-2 rounded"
+        placeholder="Descrição"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <input
+        type="datetime-local"
+        className="border p-2 rounded"
+        value={startedAt}
+        onChange={(e) => setStartedAt(e.target.value)}
+      />
+      <button type="submit" className="bg-black text-white p-2 rounded">
+        Salvar
+      </button>
+    </form>
+  )
+}
+

--- a/src/app/dashboard/projects/[slug]/incidents/page.tsx
+++ b/src/app/dashboard/projects/[slug]/incidents/page.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useSupabaseClient, useUser } from '@supabase/auth-helpers-react'
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+
+interface Project {
+  id: string
+  name: string
+  user_id: string
+}
+
+interface Service {
+  id: string
+  name: string
+}
+
+interface Incident {
+  id: string
+  service_id: string
+  title: string
+  description: string | null
+  status: 'open' | 'resolved'
+  started_at: string
+  resolved_at: string | null
+}
+
+export default function IncidentsPage() {
+  const supabase = useSupabaseClient()
+  const user = useUser()
+  const router = useRouter()
+  const { slug } = useParams<{ slug: string }>()
+
+  const [project, setProject] = useState<Project | null>(null)
+  const [services, setServices] = useState<Service[]>([])
+  const [openIncidents, setOpenIncidents] = useState<Incident[]>([])
+  const [resolvedIncidents, setResolvedIncidents] = useState<Incident[]>([])
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [loading, setLoading] = useState(true)
+
+  const formatDate = (date: string) => {
+    const d = new Date(date)
+    return (
+      d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'long' }) +
+      ' às ' +
+      d.toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+    )
+  }
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user || !slug) return
+      const { data: proj } = await supabase
+        .from('projects')
+        .select('id,name,user_id')
+        .eq('slug', slug)
+        .single()
+      if (!proj || proj.user_id !== user.id) {
+        alert('Projeto não encontrado')
+        router.replace('/dashboard')
+        return
+      }
+      setProject(proj)
+      const { data: servs } = await supabase
+        .from('services')
+        .select('id,name')
+        .eq('project_id', proj.id)
+      setServices(servs || [])
+      const ids = servs?.map((s) => s.id) || []
+      if (ids.length > 0) {
+        const { data: open } = await supabase
+          .from('incidents')
+          .select('*')
+          .in('service_id', ids)
+          .eq('status', 'open')
+          .order('started_at', { ascending: false })
+        const { data: resolved } = await supabase
+          .from('incidents')
+          .select('*')
+          .in('service_id', ids)
+          .eq('status', 'resolved')
+          .order('started_at', { ascending: false })
+        setOpenIncidents(open || [])
+        setResolvedIncidents(resolved || [])
+      }
+      setLoading(false)
+    }
+    load()
+  }, [user, slug, supabase, router])
+
+  const serviceMap = new Map(services.map((s) => [s.id, s.name]))
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const closeIncident = async (id: string) => {
+    if (!confirm('Encerrar incidente?')) return
+    const { error } = await supabase
+      .from('incidents')
+      .update({ status: 'resolved', resolved_at: new Date().toISOString() })
+      .eq('id', id)
+    if (!error) {
+      setOpenIncidents((incs) => incs.filter((i) => i.id !== id))
+      const inc = openIncidents.find((i) => i.id === id)
+      if (inc) {
+        setResolvedIncidents((incs) => [
+          { ...inc, status: 'resolved', resolved_at: new Date().toISOString() },
+          ...incs,
+        ])
+      }
+    } else {
+      alert(error.message)
+    }
+  }
+
+  if (loading) return <div>Carregando...</div>
+  if (!project) return null
+
+  return (
+    <div className="space-y-4 max-w-2xl mx-auto">
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">{project.name} - Incidentes</h1>
+        <div className="space-x-2">
+          <a
+            href={`/dashboard/projects/${slug}/services`}
+            className="underline text-sm"
+          >
+            Serviços
+          </a>
+          <a
+            href={`/dashboard/projects/${slug}/incidents/new`}
+            className="bg-black text-white px-3 py-1 rounded"
+          >
+            Novo Incidente
+          </a>
+        </div>
+      </div>
+
+      <div>
+        <h2 className="font-semibold mb-2">Abertos</h2>
+        {openIncidents.length === 0 && (
+          <p className="text-sm text-gray-500">Nenhum incidente aberto.</p>
+        )}
+        <ul className="space-y-2">
+          {openIncidents.map((i) => (
+            <li key={i.id} className="border p-2 rounded">
+              <div className="flex justify-between items-start">
+                <div>
+                  <p className="font-semibold">{i.title}</p>
+                  <p className="text-sm text-gray-600">
+                    Serviço: {serviceMap.get(i.service_id) || i.service_id}
+                  </p>
+                  <p className="text-sm">Início: {formatDate(i.started_at)}</p>
+                  {expanded.has(i.id) && i.description && (
+                    <p className="text-sm mt-1 whitespace-pre-wrap">
+                      {i.description}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2 text-right">
+                  <span className="px-2 py-1 rounded text-white bg-red-500 text-sm">
+                    aberto
+                  </span>
+                  <div className="space-x-2 text-sm">
+                    <button
+                      onClick={() => toggle(i.id)}
+                      className="underline"
+                    >
+                      {expanded.has(i.id) ? 'Ocultar' : 'Ver detalhes'}
+                    </button>
+                    <button
+                      onClick={() => closeIncident(i.id)}
+                      className="underline text-green-600"
+                    >
+                      Encerrar
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div>
+        <h2 className="font-semibold mb-2">Resolvidos</h2>
+        {resolvedIncidents.length === 0 && (
+          <p className="text-sm text-gray-500">Nenhum incidente resolvido.</p>
+        )}
+        <ul className="space-y-2">
+          {resolvedIncidents.map((i) => (
+            <li key={i.id} className="border p-2 rounded">
+              <div className="flex justify-between items-start">
+                <div>
+                  <p className="font-semibold">{i.title}</p>
+                  <p className="text-sm text-gray-600">
+                    Serviço: {serviceMap.get(i.service_id) || i.service_id}
+                  </p>
+                  <p className="text-sm">Início: {formatDate(i.started_at)}</p>
+                  {i.resolved_at && (
+                    <p className="text-sm">Fim: {formatDate(i.resolved_at)}</p>
+                  )}
+                  {expanded.has(i.id) && i.description && (
+                    <p className="text-sm mt-1 whitespace-pre-wrap">
+                      {i.description}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2 text-right">
+                  <span className="px-2 py-1 rounded text-white bg-gray-500 text-sm">
+                    resolvido
+                  </span>
+                  <button
+                    onClick={() => toggle(i.id)}
+                    className="underline text-sm"
+                  >
+                    {expanded.has(i.id) ? 'Ocultar' : 'Ver detalhes'}
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/dashboard/projects/[slug]/services/page.tsx
+++ b/src/app/dashboard/projects/[slug]/services/page.tsx
@@ -67,12 +67,20 @@ export default function ServicesPage() {
     <div className="space-y-4 max-w-2xl mx-auto">
       <div className="flex justify-between items-center">
         <h1 className="text-xl font-bold">{project.name}</h1>
-        <a
-          href={`/dashboard/projects/${slug}/services/new`}
-          className="bg-black text-white px-3 py-1 rounded"
-        >
-          Novo Serviço
-        </a>
+        <div className="space-x-2">
+          <a
+            href={`/dashboard/projects/${slug}/incidents`}
+            className="underline text-sm"
+          >
+            Incidentes
+          </a>
+          <a
+            href={`/dashboard/projects/${slug}/services/new`}
+            className="bg-black text-white px-3 py-1 rounded"
+          >
+            Novo Serviço
+          </a>
+        </div>
       </div>
       <table className="w-full border text-sm">
         <thead>


### PR DESCRIPTION
## Summary
- allow listing, creating and closing incidents
- link incidents from services page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68582ad5f180832eb0aa41a068027cce