### PR TITLE
Add links to public service and history

### DIFF
--- a/src/app/dashboard/projects/[slug]/services/page.tsx
+++ b/src/app/dashboard/projects/[slug]/services/page.tsx
@@ -25,6 +25,7 @@ export default function ServicesPage() {
   const [project, setProject] = useState<Project | null>(null)
   const [services, setServices] = useState<Service[]>([])
   const [loading, setLoading] = useState(true)
+  const publicUrl = `${process.env.NEXT_PUBLIC_STATUS_BASE_URL || ''}/status/${slug}`
 
   useEffect(() => {
     const load = async () => {
@@ -73,6 +74,12 @@ export default function ServicesPage() {
             className="underline text-sm"
           >
             Incidentes
+          </a>
+          <a
+            href={publicUrl}
+            className="underline text-sm"
+          >
+            Página Pública
           </a>
           <a
             href={`/dashboard/projects/${slug}/services/new`}

--- a/src/app/status/[slug]/page.tsx
+++ b/src/app/status/[slug]/page.tsx
@@ -118,6 +118,7 @@ export default async function Page({
               <th className="p-2 text-left">Serviço</th>
               <th className="p-2">Status</th>
               <th className="p-2">Última checagem</th>
+              <th className="p-2">Histórico</th>
             </tr>
           </thead>
           <tbody>
@@ -141,6 +142,14 @@ export default async function Page({
                   {s.last_checked_at
                     ? new Date(s.last_checked_at).toLocaleString()
                     : '-'}
+                </td>
+                <td className="p-2 text-center">
+                  <a
+                    href={`/dashboard/projects/${slug}/services/${s.id}/history`}
+                    className="underline"
+                  >
+                    Histórico
+                  </a>
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- link to the public status page from the project services dashboard
- expose link to each service history on the public status page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858c13618f4832ebb5ab3ed1138d4f3